### PR TITLE
Fix CPU Usage in miner, and avoid DOS trigger in wallet

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1532,6 +1532,22 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         const CBlockIndex* pIndex0 = GetLastBlockIndex(pindexBest, false);
         int64 nCreditReward = GetProofOfStakeReward(nCoinAge, nBits ,pIndex0->nHeight);
         //printf("nCreditReward create=%i \n", nCreditReward);
+
+        /* BANDAID 
+         * This is a quick bandaid to keep the wallet from triggering DOS rules
+         * When a proper fix is implemented this insures these blocks are well below 
+         * the stake limit and will not be rejected, which would cause a fork
+         * (~24 coins)
+         */
+        if(nCreditReward > nCombineThreshold)
+        {
+            printf("CreateCoinStake(DEBUG): Halving nCreditReward to avoid DOS rule!\n");
+            nCreditReward = nCombineThreshold / 2; // could just max the reward for now?
+        }
+        /* END BANDAID */
+
+
+
         nCredit = nCredit + nCreditReward;
     }
 


### PR DESCRIPTION
This should help keep things moving, I would highly recommend increasing the sleep of 1 second to a minute, see comments in code.

Orphan blocks are going to need some serious work, and firing off Stakes all at once will increase the chance of that, plus keeping the block chain moving at a steady rate is a good goal, that also keeps the wallet running for bit longer vs opening, watching all your coins stake, and shutting off.
