### PR TITLE
Fix 100% CPU Usage in miner

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -554,7 +554,11 @@ void static FlappycoinMiner(CWallet *pwallet)
 
             auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey, fProofOfStake));
             if (!pblocktemplate.get())
+            {
+                // Nothing to mine, sleep it off...
+                MilliSleep(1000);
                 continue;
+            }
             CBlock *pblock = &pblocktemplate->block;
             IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
 


### PR DESCRIPTION
Currently CreateNewBlock has a if/else statement to "attempt to find a coinstake", if it is PoS and there is no coinstake to be had, it will fall through to the end of the function.

The check for IsProofOfStake() && fProofOfStake will return null.

The miner thread will just loop with no sleep(100% cpu) as pblock is null.   So we are sitting at 100% cpu until we can create a coinstake.

Any amount of sleep will work, 200msec, 500msec, a second, anything that will allow the thread to sleep instead of runaway.
