### PR TITLE
Coinbase pays too much(quickfix)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2114,7 +2114,7 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
         // We only do this for blocks after the last checkpoint (reorganisation before that
         // point should only happen with -reindex/-loadblock, or a misbehaving peer.
         BOOST_FOREACH(const CTransaction& tx, block.vtx)
-            if (!tx.IsCoinBase() && pindex->nHeight > Checkpoints::GetTotalBlocksEstimate())
+            if (!(tx.IsCoinBase() || tx.IsCoinStake()) && pindex->nHeight > Checkpoints::GetTotalBlocksEstimate())
                 vResurrect.push_back(tx);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -953,7 +953,7 @@ bool CWalletTx::AcceptWalletTransaction(bool fCheckInputs)
         // Add previous supporting transactions first
         BOOST_FOREACH(CMerkleTx& tx, vtxPrev)
         {
-            if (!tx.IsCoinBase())
+            if (!(tx.IsCoinBase() || tx.IsCoinStake()))
             {
                 uint256 hash = tx.GetHash();
                 if (!mempool.exists(hash) && pcoinsTip->HaveCoins(hash))

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -369,6 +369,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, bool fProofOfStake
             pblocktemplate->vTxFees[0] = -nFees;
         }
 
+/*
         int numTxs = (int)pblock->vtx.size();
         int i = 0;
         int64 totalIn = 0;
@@ -383,6 +384,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, bool fProofOfStake
         {
             pblock->vtx[1].vout[1].AddValue( (totalIn - totalOut) );
         }
+*/
 
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -369,7 +369,6 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, bool fProofOfStake
             pblocktemplate->vTxFees[0] = -nFees;
         }
 
-/*
         int numTxs = (int)pblock->vtx.size();
         int i = 0;
         int64 totalIn = 0;
@@ -384,7 +383,6 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, bool fProofOfStake
         {
             pblock->vtx[1].vout[1].AddValue( (totalIn - totalOut) );
         }
-*/
 
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1003,7 +1003,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     bool fAllAccounts = (strAccount == string("*"));
 
     // Sent
-    if ((!wtx.IsCoinStake() && !listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
+    if (!wtx.IsCoinStake() && (!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
     {
         BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64)& s, listSent)
         {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -986,7 +986,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
             if (fOnlyConfirmed && !pcoin->IsConfirmed())
                 continue;
 
-            if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
+            if ((pcoin->IsCoinBase() || pcoin->IsCoinStake()) && pcoin->GetBlocksToMaturity() > 0)
                 continue;
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1530,6 +1530,12 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         const CBlockIndex* pIndex0 = GetLastBlockIndex(pindexBest, false);
         int64 nCreditReward = GetProofOfStakeReward(nCoinAge, nBits ,pIndex0->nHeight);
         //printf("nCreditReward create=%i \n", nCreditReward);
+
+        // Quickfix: to avoid "coinbase pays to much"
+        if(nCreditReward > nCombineThreshold)
+        {
+          nCreditReward = nCombineThreshold;
+        }
         nCredit = nCredit + nCreditReward;
     }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -604,7 +604,7 @@ int CWalletTx::GetRequestCount() const
     int nRequests = -1;
     {
         LOCK(pwallet->cs_wallet);
-        if (IsCoinBase())
+        if (IsCoinBase() || IsCoinStake())
         {
             // Generated block
             if (hashBlock != 0)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -808,7 +808,7 @@ void CWallet::ReacceptWalletTransactions()
         BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
         {
             CWalletTx& wtx = item.second;
-            if (wtx.IsCoinBase() && wtx.IsSpent(0))
+            if ((wtx.IsCoinBase() && wtx.IsSpent(0)) || (wtx.IsCoinStake() && wtx.IsSpent(1)))
                 continue;
 
             CCoins coins;
@@ -838,7 +838,7 @@ void CWallet::ReacceptWalletTransactions()
             else
             {
                 // Re-accept any txes of ours that aren't already in a block
-                if (!wtx.IsCoinBase())
+                if (!(wtx.IsCoinBase() || wtx.IsCoinStake()))
                     wtx.AcceptWalletTransaction(false);
             }
         }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2150,7 +2150,7 @@ void CWallet::GetAllReserveKeys(set<CKeyID>& setAddress)
     }
 }
 
-void CWallet::UpdatedTransaction(const uint256 &hashTx)
+void CWallet::UpdatedTransaction(const uint256 &hashTx, bool fDeleted)
 {
     {
         LOCK(cs_wallet);
@@ -2158,6 +2158,8 @@ void CWallet::UpdatedTransaction(const uint256 &hashTx)
         map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(hashTx);
         if (mi != mapWallet.end())
             NotifyTransactionChanged(this, hashTx, CT_UPDATED);
+        else if (fDeleted)
+            NotifyTransactionChanged(this, hashTx, CT_DELETED);
     }
 }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -858,11 +858,11 @@ void CWalletTx::RelayWalletTransaction()
         // Important: versions of bitcoin before 0.8.6 had a bug that inserted
         // empty transactions into the vtxPrev, which will cause the node to be
         // banned when retransmitted, hence the check for !tx.vin.empty()
-        if (!tx.IsCoinBase() && !tx.vin.empty())
+        if (!(tx.IsCoinBase() || tx.IsCoinStake()) && !tx.vin.empty())
             if (tx.GetDepthInMainChain() == 0)
                 RelayTransaction((CTransaction)tx, tx.GetHash());
     }
-    if (!IsCoinBase())
+    if (!(IsCoinBase() || IsCoinStake()))
     {
         if (GetDepthInMainChain() == 0) {
             uint256 hash = GetHash();

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1968,7 +1968,7 @@ std::map<CTxDestination, int64> CWallet::GetAddressBalances()
             if (!pcoin->IsFinal() || !pcoin->IsConfirmed())
                 continue;
 
-            if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
+            if ((pcoin->IsCoinBase() || pcoin->IsCoinStake()) && pcoin->GetBlocksToMaturity() > 0)
                 continue;
 
             int nDepth = pcoin->GetDepthInMainChain();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -278,7 +278,7 @@ public:
 
     bool DelAddressBookName(const CTxDestination& address);
 
-    void UpdatedTransaction(const uint256 &hashTx);
+    void UpdatedTransaction(const uint256 &hashTx, bool fDeleted);
 
     void PrintWallet(const CBlock& block);
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -312,6 +312,9 @@ public:
     // get the current wallet format (the oldest client version guaranteed to understand this wallet)
     int GetVersion() { return nWalletVersion; }
 
+    // ppcoin
+    void DisableTransaction(const CTransaction &tx);
+
     /** Address book entry changed.
      * @note called with lock cs_wallet held.
      */
@@ -547,6 +550,18 @@ public:
         if (!vfSpent[nOut])
         {
             vfSpent[nOut] = true;
+            fAvailableCreditCached = false;
+        }
+    }
+
+    void MarkUnspent(unsigned int nOut)
+    {
+        if (nOut >= vout.size())
+            throw std::runtime_error("CWalletTx::MarkUnspent() : nOut out of range");
+        vfSpent.resize(vout.size());
+        if (vfSpent[nOut])
+        {
+            vfSpent[nOut] = false;
             fAvailableCreditCached = false;
         }
     }


### PR DESCRIPTION
You can pull if you want it, this is what I am currently running to avoid coinbase pays too much.

Dont know if the block is "in tact" without the nCreditReward fix though, it would take some looking at.

From the look of it a better solution is to solve this in main.cpp(if I did that my blocks would be rejected though, so you'll have to)

maybe add an if(!POS) 

```
    if (vtx[0].GetValueOut() > GetBlockValue(pindex->nHeight, nFees, prevHash))
        return state.DoS(100, error("ConnectBlock() : coinbase pays too much (actual=%"PRI64d" vs limit=%"PRI64d")", vtx[0].GetValueOut(), GetBlockValue(pindex->nHeight, nFees, prevHash)));
```

CheckInputs appears to be checking the stake amount...
