### PR TITLE
Fixing error related to undefined function.

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -193,7 +193,7 @@ Value getblock(const Array& params, bool fHelp)
     {
         unsigned int size = pblockindex->nTx;
         char buffer[33];
-        itoa(size,buffer,10);
+        sprintf(size,buffer,10);
         return buffer;
     }
 


### PR DESCRIPTION
Changed a reference from itoa to sprintf because not all compilers support itoa, however I am unsure if this is a complete drop in replacement or if some sort of specific behavior is required from itoa.  It would appear that the issues page is also disabled for this repository?  Feel free to review this, it now compiles for me with Qt Creator 5.4.1.
